### PR TITLE
Increased timeout for puppeteer SW finder

### DIFF
--- a/Services/PuppeteerDetector.cs
+++ b/Services/PuppeteerDetector.cs
@@ -26,7 +26,7 @@ namespace PWABuilder.ServiceWorkerDetector.Services
         private readonly AnalyticsService analyticsService;
 
         private const int chromeRevision = 869685;  // Each build of Puppeteer uses a specific Chromium version. See https://github.com/puppeteer/puppeteer/releases for which version of Chromium should work. Check Puppeteer-Sharp's default Chromium version: https://github.com/hardkoded/puppeteer-sharp/blob/master/lib/PuppeteerSharp/BrowserFetcher.cs
-        private static readonly int serviceWorkerDetectionTimeoutMs = (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
+        private static readonly int serviceWorkerDetectionTimeoutMs = (int)TimeSpan.FromSeconds(20).TotalMilliseconds;
         private static readonly TimeSpan httpTimeout = TimeSpan.FromSeconds(5);
 
         public PuppeteerDetector(
@@ -357,8 +357,8 @@ namespace PWABuilder.ServiceWorkerDetector.Services
             var browser = await CreateBrowser(chromeInfo);
             Page page;
             try
-            {
-                page = await GoToPage(uri, browser);
+            {          
+                page = await GoToPage(uri, browser);              
             }
             catch (Polly.Timeout.TimeoutRejectedException)
             {
@@ -369,7 +369,6 @@ namespace PWABuilder.ServiceWorkerDetector.Services
                 browser.Dispose();
                 throw;
             }
-
             ServiceWorkerExistsResult workerDetection;
             try
             {


### PR DESCRIPTION
# Fixes 
https://github.com/pwa-builder/PWABuilder/issues/2498

## PR Type
Bugfix

## Describe the current behavior?
For some sites the service worker detector takes 10-20 seconds to complete and since there is a 10 second timeout. some sites are being judged incorrectly on their service worker. (ie, sites with service workers are told they do not have one just because the detection takes > 10 seconds.)

## Describe the new behavior?
We increased the timeout to 20 seconds. The two sites we had to test for this bug both completed from 11-17 seconds, and we felt like a 10 second increase to the timeout would not be detrimental to the user experience. We review the code thoroughly and agreed that the way the timeouts are currently used, there was nothing that could be done to shorten the timeout. (With the manifest detection timeout error, that we faced in the past, we found that the 10 second timeout was covering more than just the detection steps, leaving the detection with a true timeout of < 10 seconds. This is not the case in the service worker detection logic.)

## PR Checklist
- [x] Test: run `npm run test` and ensure that all tests pass
- [x] Target main branch (or an appropriate release branch if appropriate for a bug fix)
- [x] Ensure that your contribution follows [standard accessibility guidelines](https://docs.microsoft.com/en-us/microsoft-edge/accessibility/design). Use tools like https://webhint.io/ to validate your changes.

## Additional Information
- Keep an eye out for future for patterns with service worker detection issues. We are trying to understand why some sites take longer than others and since we only have 2 sites where this happens right now it is hard to tell. The only commonality these two sites have is that they are both in foreign languages which could be linked to this issue.
- Special thank you to @amrutha95 and @maraah1 for doing a pair programming session on this one!